### PR TITLE
Migrate AQ2 to new celer

### DIFF
--- a/routes/aq2/IST.txt
+++ b/routes/aq2/IST.txt
@@ -1,0 +1,108 @@
+##########
+# Plateau 
+##########
+# KEEP FULL AXE
+get 1 slate 1 tree branch 1 flint 1 axe 1 spear 1 potlid 6 pepper 3 shroom 1 amber 1 traveler bow 5 arrow 4 orb 1 glider
+# Satori
+get 2 razorshroom 5 lotus 4 rushroom 1 forest dweller bow 4 endura carrot 10 durian 3 wood 1 orb
+# Castle
+# KEEP FULL ROYAL CLAYMORE (except the initial sneakstrike)
+get 1 royal claymore[life=3900] 1 royal guard claymore 1 razorshroom 1 naydra fang 3 ancient arrow 1 steel shield
+equip royal guard claymore
+# cook speed food and eat
+with 3 lotus 2 rushroom
+##########
+# Guardians
+##########
+# Drop materials to make him load
+drop 1 amber 3 wood 1 naydra fang
+drop 3 razorshroom 2 rushroom
+get 1 shaft
+# PICK UP 3 things, then amber, then razorshroom last
+pick up 3 wood 1 naydra fang 2 rushroom 1 amber 3 razorshroom
+get 1 spring
+# If you don't have 5 arrows, pick up 2 screws to sell in hateno
+# Wetland, Kak, Hateno
+get 1 knights sword 1 core 1 fairy 3 orb
+has 9 weapon slots
+##########
+# After Myahm
+##########
+eat all pepper all shroom 7 durian 1 endura carrot
+drop traveler bow
+drop potlid
+equip normal arrow
+equip forest dweller bow
+equip steel shield
+equip axe
+# cycle everything between flint and shaft
+dnp all lotus all endura carrot all durian all core
+# Go to shop
+# if you don't have 5 arrows, sell something, buy 5 arrows, then save
+SAVE
+break 10 slots with 3 durian 3 wood 3 enduracarrot 3 razorshroom 2 lotus 2 rushroom
+# drop everything except core
+drop 1 flint 1 amber 1 naydra fang 1 shaft 1 spring 1 fairy
+drop all shield
+unequip bow
+unequip weapon
+reload
+shoot 1 arrow
+save
+dnp 1 core 1 shaft 3 razorshroom
+reload
+drop 5 flint 5 amber
+sell all flint all amber
+pick up 5 flint 5 amber
+# WB to statue
+# Trade 6 STAM
+sell all orb
+# Light cooking pot
+# Cook speed food first, other any order
+with 4 lotus 1 naydra fang
+cook simmered fruit[modifier=speed]
+with 6 endura carrot
+cook 2 wild green[modifier=endur]
+with 5 razorshroom
+cook mushroom skewer[modifier=mighty]
+dnp 2 core 1 shaft
+# use durian for food
+# wb to lab
+equip spear
+drop razorshroom
+drop all durian
+# drop wood and rushroom down to 1
+drop 2 wood 1 rushroom
+sell 3 core 3 shaft
+# PICK UP SPRING LAST
+dnp 2 shaft 1 spring 
+# Outside of lab
+equip royal guard claymore
+drop 1 tree branch 1 axe 1 knights sword
+save
+#pick up 3 weapon
+remove all material
+drop all bow
+# go to different pile
+remove all food
+drop all shield
+drop all weapon
+pick up 6 weapon
+pick up shield
+unequip weapon
+unequip shield
+reload
+save
+# drop all but shaft
+drop 1 wood 1 rushroom 1 fairy 1 spring
+drop 5 flints
+drop 5 amber
+remove all food
+drop all shields
+unequip weapon
+unequip bow
+reload
+save
+drop 2 shaft 1 spring
+pick up 1 shaft
+reload

--- a/routes/aq2/common/check-quest.yaml
+++ b/routes/aq2/common/check-quest.yaml
@@ -1,3 +1,0 @@
-- "Main: .var(MainQuest)/15 Completed"
-- "Side: .var(SideQuest)/77 Completed"
-- "Shrine: .var(ShrineQuest)/42 Discovered"

--- a/routes/aq2/config.yaml
+++ b/routes/aq2/config.yaml
@@ -1,0 +1,12 @@
+plugins:
+- use: botw-ability-unstable
+  with:
+    estimate-recharge: true
+- use: metrics
+  with:
+    detailed: true
+
+presets:
+  CheckQuests:
+    text: Tracker --> Main .var(MainQuest)/15; Side .var(SideQuest)/77; Shrine .var(ShrineQuest)/42
+    banner: true

--- a/routes/aq2/main.yaml
+++ b/routes/aq2/main.yaml
@@ -12,46 +12,46 @@
       color: yellow
   - use: ./sections/medoh.yaml
 - Naboris:
-  - __use__ Naboris
+  - use: ./sections/naboris.yaml
 - Hebra:
-  - __use__ Hebra
+  - use: ./sections/hebra.yaml
 - Ruta:
-  - __use__ Kak2Ruta
-  - __use__ TarreyActivateGoron
+  - use: ./sections/kak2-ruta.yaml
+  - use: ./sections/tarrey-activate-goron.yaml
 - Eldin:
-  - __use__ Eldin
-  - __use__ TarreyActivateGerudo
-  - __use__ ThundraPlateau
+  - use: ./sections/eldin.yaml
+  - use: ./sections/tarrey-activate-gerudo.yaml
+  - use: ./sections/thundra-plateau.yaml
 - Gerudo:
-  - __use__ Gerudo
+  - use: ./sections/gerudo.yaml
 - Lake:
-  - __use__ Lake
+  - use: ./sections/lake.yaml
 - Rudania:
-  - __use__ Rudania
+  - use: ./sections/rudania.yaml
 - Korok Forest:
-  - __use__ KorokForest
-  - __use__ KorokForest2
+  - use: ./sections/korok-forest.yaml
+  - use: ./sections/korok-forest2.yaml
 - Central:
-  - __use__ Central
+  - use: ./sections/central.yaml
 - Kakariko:
-  - __use__ TarreyActivateRito
-  - __use__ AncientColumnMemory
-  - __use__ Kak3
+  - use: ./sections/tarrey-activate-rito.yaml
+  - use: ./sections/ancient-column-memory.yaml
+  - use: ./sections/kak3.yaml
 - Faron:
-  - __use__ Faron
+  - use: ./sections/faron.yaml
 - Rito:
-  - __use__ Rito
+  - use: ./sections/rito.yaml
 - Zora's Domain:
-  - __use__ TarreyActivateZora
-  - __use__ ZDQuests
+  - use: ./sections/tarrey-activate-zora.yaml
+  - use: ./sections/zd-quests.yaml
 - Hateno:
-  - __use__ TarreyActivateHateno
-  - __use__ Hateno
+  - use: ./sections/tarrey-activate-hateno.yaml
+  - use: ./sections/hateno.yaml
 - Hebra 2:
   - (==) If it's after 10PM, do BM branch first
-  - __use__ DeepHebra
-  - __use__ BM
-  - __use__ ForgottenTemple
+  - use: ./sections/deep-hebra.yaml
+  - use: ./sections/bm.yaml
+  - use: ./sections/forgotten-temple.yaml
 - Finale:
-  - __use__ TarreyFinal
-  - __use__ Ganon
+  - use: ./sections/tarrey-final.yaml
+  - use: ./sections/ganon.yaml

--- a/routes/aq2/project.yaml
+++ b/routes/aq2/project.yaml
@@ -1,14 +1,9 @@
-title: All Quest
-version: 2.1.1
+title: All Quests
+version: 2.2
 config:
 - use: Pistonight/celer-presets/botw/full.yaml
 - use: ../../common/config.yaml
-- plugins:
-  - use: botw-ability-unstable
-    with:
-      estimate-recharge: true
-  - use: metrics
-    with:
-      detailed: true
+- use: ./config.yaml
+
 route:
   use: ./main.yaml

--- a/routes/aq2/sections/ancient-column-memory.yaml
+++ b/routes/aq2/sections/ancient-column-memory.yaml
@@ -1,0 +1,6 @@
+- _Warp::Shrine::TenaKosah:
+    color: orange
+- _Memory::AncientColumns
+- .dir(.W) DT
+- _Shrine::KahOkeo:
+    comment: Under slab

--- a/routes/aq2/sections/bm.yaml
+++ b/routes/aq2/sections/bm.yaml
@@ -1,0 +1,10 @@
+- _Warp::Shrine::MoggLatan:
+    color: orange
+- .dir(E>>) Turn
+- _Npc<Kass>:
+    notes: '[Under a Red Moon] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-2778.84, 348.24, 206.35]
+- Make night if needed
+- _Shrine::MijahRokee

--- a/routes/aq2/sections/central.yaml
+++ b/routes/aq2/sections/central.yaml
@@ -1,0 +1,136 @@
+- .dir(S>>) ordinal turn escape
+- .dir(S>) turn to Zelda's study
+- _Memory::HyruleCastle
+- BLSS to back of castle
+- _Chest<Dinraal Scale>:
+    comment: behind bombable rocks
+    coord: [-196.46, 153.2, -1218.59]
+- WB right of chest to docks:
+    coord: [-310, -1136.8678805645532]
+- _Shrine::SaasKosah
+- Run to library, WB off table out:
+    movements:
+    - to: [-142.5, -1046.3013256465474]
+    - to: [-64, -1042.7999390857558]
+- WB towards back of castle
+- _Chest<Naydra Scale>:
+    comment: under slab
+    coord: [-176.5, -1167.6024074184797]
+- BLSS .dir(W)
+- _Memory::IrchPlain
+- BLSS .dir(<S)
+- _Shrine::NoyaNeha
+- Burn thorns + .dir(W) super
+- _Shrine::ZaltaWa
+- .dir(S>) + .dir(<W) Turn midair:
+    coord: [-1524.5, -472.5067347238455]
+- _Material<Monster Extract>:
+    comment: Save traveller
+    coord: [-1864.5, 216.0, -275.0]
+- .dir(S) Fast Turn
+- _Shrine::SheemDagoze
+- .dir(E) Fast Turn
+- _Npc<Kass>:
+    notes: '[The Two Rings] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-1681.68, 214.5, 51.38]
+- .dir(<S) Turn + .dir(S)
+- _Memory::SanidinPark
+- SQ to white horse
+- Ride to stable:
+    movements:
+    - to: [-1914, 926.7463658662109]
+    - to: [-1954, 1006.7780586843091]
+    - to: [-1906, 1074.804997579693]
+    - to: [-1626, 1032.7883588501918]
+    - to: [-1530, 1022.7843972479295]
+    - to: [-1450, 1270.8826449840335]
+- _Npc<Meat Guy>:
+    comment: Talk Twice
+    notes: '[A Rare Find] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-1439, 1280.0853725287516]
+- _Npc<Register Horse>:
+    comment: Text Options 2-1-1-1-A-+-1-1
+- _Npc<Horse Guy>:
+    notes: '[The Royal White Stallion] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-1439.25, 137.72, 1278.45]
+- _Npc<Fan Girl>:
+    comment: Second Option
+    notes: '[My Hero] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-1400.0, 137.72, 1280.0]
+- .dir(.W)
+- _Shrine::RotaOoh
+- BLSS .dir(E):
+    coord: [-1164, 1189.2048148369595]
+- _Memory::LakeKolomo
+- .dir(<N) Slight TS
+- _Shrine::KaamYatak
+- .dir(<E) Turn + BLSS .dir(N):
+    notes: If you somehow didn't get 3 screws from yunobo escort, kill a stalker at
+      central hyrule
+- _Shrine::KatahChuki
+- .dir(E>) TS
+- _Memory::SacredGrounds
+- .dir(E>>) TS + .dir(E>) Turn:
+    notes: Second super from a tree
+- _Memory::HyruleField
+- .dir(<S) Turn:
+    notes: Chop the closest tree
+- _Shrine::HilaRao
+- _Npc<Flower Lady>:
+    notes: '[Watch Out for the Flowers] Shrine Quest. Faster to run to her and talk'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [817.5, 851.7619838468436]
+- .dir(<W) Turn
+- .important(EQUIP RGC):
+    notes: It's faster to talk to the girl later with rgc already equipped
+- _Shrine::WahgoKatta
+- SQ to stable
+- _Npc<Royal Guard Girl>:
+    comment: Talk Twice
+    notes: '[The Royal Guard''s Gear] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [347, 1082.8428766757988]
+- _Npc<Chef>:
+    comment: Talk Twice
+    notes: '[A Royal Recipe] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [324, 1107.8527806814545]
+- _Cook<Monster Cake>:
+    comment: Wheat Sugar Butter Extract
+    icon-map: null
+- _Tod::Night:
+    comment: If <7PM
+    notes: For Xenoblade. If it's after 7PM you don't need to make night
+- .dir(S>) Turn
+- Kill .enemy(Moblin):
+    notes: Kill with RGC, cut the tree, then throw away RGC
+- _Equipment::Weapon<Moblin Club>:
+    coord: [132.65, 116.42, 1397.9]
+- .dir(S)
+- _Shrine::BoshKala
+- .dir(<S)
+- _Memory::WestNecluda
+- .dir(S>) Turn
+- Middle of bridge look .dir(SE)
+- _Shrine::YaNaga
+- .dir(E)
+- _Npc::ZoraFemale<Fronk's Wife>:
+    notes: Finish A Wife Washed Away Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [-205, 2613.7491847822967]
+- .dir(E>) Turn
+- _Chest::Special<Salvager Headwear>:
+    coord: [126.03, 92.65, 2710.94]
+- _CheckQuests

--- a/routes/aq2/sections/deep-hebra.yaml
+++ b/routes/aq2/sections/deep-hebra.yaml
@@ -1,0 +1,9 @@
+- _Warp::Shrine::ShadaNaw:
+    color: orange
+- BLSS .dir(W):
+    time-override: 45
+- _Shrine::HiaMiu
+- .dir(E) + clip:
+    time-override: 60
+- _Shrine::ToQuomo
+- _Snap::Quest<Hebra Skeleton>

--- a/routes/aq2/sections/eldin.yaml
+++ b/routes/aq2/sections/eldin.yaml
@@ -1,0 +1,154 @@
+- _Warp::Shrine::DagahKeek:
+    color: '#00ff00'
+- .dir(N) + midair
+- .loc(Monument):
+    comment: Side of mountain
+    icon: npc-zora-male
+    coord: [3224.5, -742.9558281347754]
+- .dir(W>) + .dir(W) + .dir(W)
+- .loc(Monument):
+    comment: Middle of water fall
+    icon: npc-zora-male
+    coord: [3707.5, -523.3688709651187]
+- .dir(N) to top of waterfall:
+    coord: [3745, -630.4112601093257]
+- .dir(N.) DT
+- _Shrine::DahHesho
+- .dir(N.) Turn to Tarrey Town:
+    coord: [3984.5, -1597.5796282054716]
+- _Npc<Hudson>:
+    comment: Talk Twice
+- .dir(<W) Turn
+- Kill .enemy(2 Stalkers):
+    time-override: 40
+    movements:
+    - to: [3682, -1510.9084045459003]
+    - to: [3626.5, -1601.443160892215]
+- _Snap::Quest<Guardian Stalker>:
+    notes: Snap while they explode
+- .dir(W>) + .dir(W>) midairs
+- _Material<Armoranth>:
+    coord: [3256, -1740.5062927691179]
+- Cut tree SQ to stable
+- _Npc<Darner Quest>:
+    notes: '[Little Sister''s Big Request] Side Quest. Talk to big sister (2nd option),
+      then little sister, big sister, little sister, big sister'
+    time-override: 30
+    vars:
+      SideQuest: .add(1)
+    coord: [3142, -1690.6525216870973]
+- .dir(.W) to shrine:
+    notes: WB from the tree is possible, but getting bullet time is tricky. Use the
+      wood crates to be more consistent
+- _Shrine::ZeKasho
+- .gale() + .dir(.W) Turn midair:
+    gale: 1
+- _Shrine::SahDahaj
+- .dir(<<S) + .dir(S>) Turn:
+    coord: [2780, -1391.0176662091762]
+- _Shrine::MoaKeet
+- SQ to stable
+- _Npc<Shrine Painting Guy>:
+    notes: '[A Landscape of a Stable] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [2610, -1140.0332774590024]
+- .dir(<W) Turn
+- _Shrine::TahMuhl
+- .dir(W) + .dir(N) + .dir(W) + .dir(<N) Turn:
+    movements:
+    - to: [2147, -937.8436924535913]
+    - to: [2150, -1109.9097487139898]
+    - to: [1942, -1184.938552315908]
+- _Shrine::QuaRaym
+- .dir(W) + .dir(W):
+    notes: Wait for Link to take burn damage before second wb
+- _Memory::EldinCanyon:
+    time-override: 60
+- .dir(N>) Turn to .loc(South Mine):
+    coord: [1804.5, -1729.7964545464456]
+- _Material<10 Lizards>:
+    notes: null
+    time-override: 30
+    movements:
+    - to: [1701.79, 430.53, -1932.14]
+    - to: [1712.06, 430.61, -1939.71]
+    - to: [1717.88, 431.01, -1938.83]
+    - to: [1722.51, 431.35, -1950.52]
+    - to: [1728.43, 435.44, -1976.95]
+    - to: [1723.81, 432.41, -1996.84]
+    - to: [1717.02, 432.55, -1996.47]
+    - to: [1714.66, 432.56, -1996.17]
+    - to: [1701.37, 431.47, -1982.87]
+    - to: [1683.16, 430.31, -1948.15]
+- _Npc<Lizard Guy>:
+    comment: Equip armor
+    notes: '[Fireproof Lizard Roundup] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [1657.35, 430.17, -1960.6]
+- _Tod::Night:
+    notes: Should be around 7PM. If past night, you also need to make night here for
+      Xenoblade (<3AM), Kilton (<4AM) and East Akkala (>5AM). You can make night later
+      if need.
+- _Npc<Greyson>
+- .dir(<N) Turn + .dir(NE):
+    coord: [1497, -2304.8171931398265]
+- _Npc::Goron<Shrine Brother>:
+    comment: Text Options 2-1
+    notes: '[A Brother''s Roast] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [1644.75, -2463.0383285018875]
+- _Shop<Buy 1 Goron Splice>:
+    coord: [1680, -2460.2244608062992]
+- _Npc::Goron<Bludo>:
+    notes: '[Divine Beast Vah Rudania] Main Quest'
+    coord: [1705.75, -2447.75]
+- .dir(N>)
+- _Shrine::ShaeMosah
+- .dir(<N) Turn
+- _Npc::Goron<Rescue Yunobo>:
+    coord: [1635, -2936.561622231986]
+- .dir(W.) Turn
+- _Boss::Talus::Igneo:
+    comment: .fury()
+    fury: 3
+    coord: [1337, -3051.971476463712]
+- .dir(<E)
+- _Shrine::ShoraHah
+- Minecart + .dir(N.):
+    coord: [1727, -3315.1350048347513]
+- _Snap::Quest<Eldin Skeleton>:
+    movements:
+    - push
+    - to: [1580, -3666.1171593680883]
+      color: white
+      icon: camera
+    - pop
+- .dir(E) Turn + .dir(E) Turn
+- _Npc<Gut Check Goron>:
+    notes: '[The Gut Check Challenge] Shrine Quest. 2 WB up to the final 5 red rupees.
+      Eat a stam food, but keep the yellow stam for Lynel later'
+    time-override: 40
+    vars:
+      ShrineQuest: .add(1)
+    coord: [2670.5, -3468.808037473142]
+- _Shrine::GoraeTorr
+- .dir(E) Turn:
+    coord: [3322, -3429]
+- .important(Look Sky .dir(E))
+- Activate Zuna Kai:
+    notes: Activate the shrine here so you don't reach the chest too fast. The stal
+      moblins will spawn faster and mess you up.
+- .dir(<E) Turn
+- _Chest::Special<Salvager Vest>:
+    notes: '[[Xenoblade Chronicles 2]] Side Quest'
+    coord: [3636.0, 302.0, -3520.0]
+- .dir(<W) Turn
+- _Shrine::ZunaKai
+- Drop down
+- _Snap::Quest<Kilton>:
+    notes: Snap multiple to be safe if need. Don't have to talk
+    time-override: 60
+    coord: [3247, -3440.5]

--- a/routes/aq2/sections/faron.yaml
+++ b/routes/aq2/sections/faron.yaml
@@ -1,0 +1,158 @@
+- BLSS off Elevator
+- _Shrine::ShodaSah
+- .dir(S.) Turn + .dir(SW)
+- _Npc<Quest Lady>:
+    comment: Talk Twice
+    notes: '[Thunder Magnet] Side Quest. She will be inside if thundering (5PM-9PM).
+      You can still use bomb arrow for the shrine in rain if you stand below a tree'
+    vars:
+      SideQuest: .add(1)
+    coord: [1552, 3538.710361080126]
+- _Equipment::Bow<Traveler Bow>:
+    comment: For Eventide
+    coord: [1564.5, 3546.8129894759695]
+- Bomb arrow rock
+- _Shrine::ShaiUtoh
+- .dir(E) Super + .dir(N.) midairs
+- Clip in:
+    notes: .link(https://www.youtube.com/watch?v=avrVPjqfJDQ)
+- _Shrine::QukahNata
+- Clip out + SQ
+- _Npc<Kass>:
+    notes: '[A Song of Storms] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- .dir(<E) TS to Blue Hinox:
+    coord: [2689, 2965]
+- Walk Orb:
+    coord: [2632.75, 2857]
+- .important(READ TABLET):
+    notes: '[The Three Giant Brothers] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [2655, 2842.5]
+- .important(READ TABLET)
+- .important(READ TABLET)
+- .dir(W>) to Black Hinox:
+    coord: [2419, 2779.5]
+- Walk or BLSS:
+    coord: [2615.75, 2824.5]
+- .dir(NE) to Red Hinox:
+    coord: [2767.5, 2714]
+- Walk Orb:
+    coord: [2647.5, 2820.75]
+- _Shrine::TawaJinn
+- BLSS .dir(S) to heart lake
+- _Npc<Love Quest Guy>:
+    comment: Talk Twice
+    notes: '[A Gift of Nightshade] Side Quest. Use a cryo block when going to the
+      woman'
+    coord: [2591, 3528.322870584376]
+- _Npc<Love Quest Woman>:
+    comment: Talk Twice
+    icon-map: null
+    vars:
+      SideQuest: .add(1)
+- .dir(SW)
+- .fury() the camp:
+    fury: 2
+    notes: For watch tower bokos left after fury, get BLS first, then AA him (aim
+      at branch above with falcon bow) and WALK to get slide (if you slide directly
+      in bow animation, your angle will be locked)
+    coord: [2091, 3914.4757884316987]
+- BLSS .dir(E):
+    coord: [3024, 3924.903245315798]
+- _Chest<Sapphire/Topaz>:
+    notes: Get either one on the side
+- .dir(.N) Turn
+- _Npc<Old Man>:
+    comment: 2nd Option (ocean), talk again
+    notes: '[Sunken Treasure] Side Quest. On left dock or inside house if raining'
+    vars:
+      SideQuest: .add(1)
+    coord: [2887.5, 3494.779414896797]
+- SQ across harbor
+- _Material<Hearty Blueshell Snail>:
+    coord: [2944, 3462.766737769558]
+- Cryo + SQ .dir(NW):
+    coord: [2886.5, 3409.245543197456]
+- _Npc<Mom>:
+    comment: Talk Twice
+    notes: '[What''s for Dinner?] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [2886.5, 3409.245543197456]
+- _Npc<Dad>:
+    comment: Talk Once
+    notes: '[Take Back the Sea] Side Quest. He will be inside house if rain. 5PM-6PM
+      he is at the same place with mom. There''s no good wb spot here, so you still
+      want to go down and cryo block if he is at dinner'
+    vars:
+      SideQuest: .add(1)
+    coord: [2905.5, 3438.757229924129]
+- Cryo + .dir(<N)
+- _Shrine::YahRin
+- BLSS .dir(E):
+    coord: [3797.625, 3615.5304052973624]
+- _Snap::Quest<Shard at peninsula tip>
+- .dir(NW)
+- _Snap::Quest<Shard in grassy alcove>:
+    coord: [3532.5, 3368.0035654420353]
+- .dir(SW)
+- _Snap::Quest<Shard amongst rocks>:
+    coord: [3388, 3480.548133467486]
+- .dir(N.)
+- _Npc<Guy at Monument>:
+    comment: Talk Twice
+    notes: '[A Fragmented Monument] Shrine Quest. Talk twice then crouch on pedestal'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [3464.75, 3364.751980801131]
+- _Shrine::KahYah
+- Shield surf SCW + .dir(E):
+    notes: Activate with amiibo rune
+- _Shrine::MuwoJeem
+- BLSS .dir(N) to sole rock:
+    notes: Clear skew when dropping down
+- _Npc<Kass>:
+    notes: '[The Hero''s Cache] Side Quest'
+    coord: [3745.5, 2629.544369945337]
+- Drop down .dir(SE):
+    notes: Toward Chaas Qeta Shrine
+    coord: [3774.5, 2660.3799634514535]
+- _Chest<Gold Rupee>:
+    comment: Mag out from water
+    vars:
+      SideQuest: .add(1)
+- .dir(NE) to Camp:
+    notes: For Sheep Rustlers quest
+    coord: [4088.5, 2376.5368429010387]
+- .fury() camp + AA:
+    fury: 1
+    notes: AA 2 bokos that don't die from 1 fury. Make sure chest unlocks
+- BLSS .dir(S)
+- _Shrine::ChaasQeta
+- _Equipment::Weapon<Korok Leaf>:
+    comment: Next to BLSS tree
+- BLSS .dir(SE) to Eventide:
+    notes: '[Stranded on Eventide] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [4489, 3457.2174919641984]
+- Smuggle:
+    notes: Smuggle Axe, Traveler Bow, arrow (ancient OK), Forest Dweller Shield.
+- .important(CHECK SPEED FOOD TIME)
+- Turn on Daruk's Protection
+- .gale() at the end:
+    gale: 1
+- ? End Game Time of Day cycle starts here. It's pretty tight. Ideally warp to ZD
+    around 3:30PM, finish Shai Yota branch (talk to kass) at 9PM, reach BM shrine
+    around 11:30PM to skip BM cutscene, then get to stal horse around 3:30AM (need
+    to be before 5AM)
+  : banner: true
+- _Tod::Noon:
+    comment: Before entering shrine
+    notes: If over 8:30 pace, you might get BM here, so don't make noon, finish the
+      shrine, go do BM, and make noon there
+- _Shrine::KorguChideh
+- _CheckQuests

--- a/routes/aq2/sections/forgotten-temple.yaml
+++ b/routes/aq2/sections/forgotten-temple.yaml
@@ -1,0 +1,61 @@
+- _Warp::Shrine::ShadaNaw:
+    color: magenta
+- .dir(S) + .dir(S) + .dir(E):
+    notes: To mountain top.
+    coord: [-2978, -2895.6993143882946]
+- Look Sky .dir(S):
+    notes: Make sure shooting star hits ground before going to shrine
+- _Shrine::GomaAsaagh
+- .dir(SE)
+- _Chest::Special<Salvager Trousers>:
+    vars:
+      SideQuest: .add(1)
+    coord: [-2605.0, 583.0, -2652.0]
+- .dir(S) Turn
+- _Shrine::LannoKooh
+- Cryo out + .dir(NE)
+- Snowball throw + Stasis MAX:
+    notes: Throw snowball up hill and let it roll almost all the way down
+- _Shrine::GeeHarah
+- .dir(N) + .dir(NE) + .dir(N>) Turn:
+    movements:
+    - to: [-2389, -2440.716349278022]
+    - to: [-2117, -2702.8201432572932]
+    - to: [-1909, -3068.8749923676755]
+- Land on first skull camp
+- _Snap::Quest<Stalhorse>:
+    icon-map: null
+    movements:
+    - push
+    - to: [-1797, -3196.924150514949]
+      color: white
+      icon: camera
+    - pop
+- .dir(<S) Turn
+- _Shrine::RinOyaa
+- _Npc<Stalhorse Lady>:
+    comment: Talk Twice
+    notes: '[Stalhorse Pictured!] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-1654, -2597.7785464335393]
+- BLSS .dir(<S) off chair
+- _Shrine::MonyaToma
+- .dir(W) Turn
+- _Shrine::MaagNorah
+- .dir(<<E) Turn to stable:
+    notes: Glide to a rock to the left for a better angle
+- _Npc<3 People>:
+    notes: '[Leviathan Bones] Side Quest. Talk to any of 3, then talk once to each'
+    vars:
+      SideQuest: .add(1)
+    coord: [-1543, -1796.9687033421287]
+- .dir(N>) Turn to Forgotten Temple:
+    coord: [-1430, -2245.1804415134247]
+- _Shrine::RonaKachta:
+    notes: '[A Gift from the Monks] Side Quest'
+- _Chest<Wild Set>:
+    vars:
+      SideQuest: .add(1)
+    coord: [-1060, -2694.324059065053]
+- _CheckQuests

--- a/routes/aq2/sections/ganon.yaml
+++ b/routes/aq2/sections/ganon.yaml
@@ -1,0 +1,30 @@
+- If you still need a blupee pic, warp to zuna kai now and take one:
+    banner: true
+- _Warp::Shrine::KeoRuug
+- _Npc<Blupee Quest>:
+    icon-map: null
+    notes: '[Legendary Rabbit Trial] Side Quest'
+    vars:
+      SideQuest: .add(1)
+- _Npc<Trial Korok>:
+    notes: '[The Korok Trials] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [432.25, -2167.49078927474]
+- .gale() + to top of Deku Tree:
+    gale: 2
+- Acorn BLSS to castle:
+    notes: Same as AMQ. Want to start south, then wiggle toward castle
+    coord: [-256, -1060.8995733826514]
+- ''
+- Get Skew Bounce:
+    notes: Can also just kill him normally
+- Calamity:
+    icon: calamity
+    notes: FURY + stasis 8AA headshots
+    # split-type: UserDefined
+- Dark Beast:
+    icon-doc: ganon
+    notes: Check quests after Dark Beast
+    # split-type: UserDefined
+- _CheckQuests

--- a/routes/aq2/sections/gerudo.yaml
+++ b/routes/aq2/sections/gerudo.yaml
@@ -1,0 +1,183 @@
+- _Warp::Shrine::KeehaYoog:
+    color: cyan
+    notes: Lightning pedestal shrine
+- _Tod::Morning:
+    notes: For Farosh + Gerudo Town quests
+- .dir(N) + .dir(W) + .dir(S) + .dir(S) SQ:
+    movements:
+    - to: [-3845, 605]
+    - to: [-4023, 595]
+    - to: [-4040, 770.1052291590076]
+    - to: [-4038, 881]
+- Kill .enemy(Lynel):
+    notes: Eat attack food, headshot with shock arrows, spin to win with RGC, If you
+      ate a stam food for gorae torr, you should have enough stam
+    time-override: 60
+- _Material<Lynel Hoof>
+- _Snap::Quest<Big Sword>:
+    notes: You can snap from where the lynel was. Snap the hilt
+    icon-map: null
+    movements:
+    - push
+    - to: [-3986, 970]
+      color: white
+      icon: camera
+    - pop
+- _Material<Farosh Scale>:
+    notes: Shoot Farosh after snapping the sword. Then updraft up. If the scale falls
+      on your side, drop down, get it, then windbomb from the valley. If it falls
+      on the other side, quick midair to the other side
+    coord: [-4150, 788]
+- .dir(<N) Turn:
+    coord: [-4295, 489]
+- _Snap::Quest<Eighth Heroine Statue>:
+    icon-map: null
+    movements:
+    - push
+    - to: [-4377, 524]
+      color: white
+      icon: camera
+    - pop
+- .dir(SW)
+- _Shrine::KemaKosassa
+- BLSS .dir(S)
+- _Shrine::KemaZoos
+- .dir(S>>) + .dir(S.) Turn:
+    notes: WB to far set of torches. 3 furies (this will kill the molduga near the
+      shrine), light torches, SQ WB to the other set, light torches
+- _Boss::Molduga:
+    comment: .fury(), Get Guts
+    fury: 3
+    coord: [-4810.5, 2784.5]
+- _Shrine::ThoKayu
+- BLSS .dir(S)
+- _Snap::Quest<Small Guardian>:
+    comment: Inside shrine
+    icon-map: null
+- _Shrine::HawaKoth:
+    comment: Get outside skew
+- _Snap::Quest<Gerudo Skeleton>:
+    icon-map: null
+    coord: [-4846.5, 3763.3366904384147]
+- _Npc::Gerudo<Give Barta durian>:
+    coord: [-4832.625, 3733.598231800006]
+- .dir(<<E) Turn + .dir(NE) midairs:
+    notes: Equip gerudo outfit middle
+- _Npc::Gerudo<Sand Seal Race>:
+    notes: '[The Undefeated Champ] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3764, 3129.2366464057413]
+- _Shrine::RaqaZunzo:
+    comment: Radiant shield
+- .dir(N) Turn
+- _Npc<Boots Guy>:
+    comment: Talk Three Times
+    notes: '[The Forgotten Sword] Side Quest'
+    vars:
+      SideQuest: .add(2)
+    coord: [-3760.5, 2873.5]
+- _Npc<Secret Club>:
+    comment: Password 3334
+    notes: '[The Secret Club''s Secret] Side Quest. Walk in to trigger the cutscene'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3793, 2931.5]
+- .dir(W)
+- _Npc::Gerudo<Polluting Lady>:
+    comment: Talk Twice
+    coord: [-3917.75, 2949.25]
+- Drop down
+- _Npc<Guard Captain>:
+    notes: Finish [The Search for Barta]
+    vars:
+      SideQuest: .add(1)
+    coord: [-3911.25, 2930.25]
+- _Npc::Gerudo<Molduga Guts Lady>:
+    comment: Talk Twice
+    notes: '[Medicinal Molduga] Side Quest. If after 2PM, she will be in front of
+      Riju''s palace'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3907, 2911.75]
+- Run
+- _Npc::Gerudo<Berry Girl>:
+    notes: Finish [The Mystery Polluter]
+    vars:
+      SideQuest: .add(1)
+    coord: [-3835, 2853.5]
+- Run:
+    movements:
+    - to: [-3848.75, 2878.521362671423]
+    - to: [-3838, 2890.1508272297197]
+- _Npc::Gerudo<Riju>:
+    notes: Finish [The Thunder Helm]. Talk to Riju not Thunderhelm
+    vars:
+      SideQuest: .add(1)
+    coord: [-3884.5, 2964.5]
+- Run out + Climb up
+- BLSS .dir(NE) to Kara Kara Bazaar
+- _Npc<Watchtower Guy>:
+    notes: '[The Eye of the Sandstorm] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3277, 2558]
+- Equip flamebreaker:
+    notes: Need to take off gerudo outfit to talk to Rhondson / Mipha's Grace for
+      eventide later
+- _Cook<Chilly Elixir>:
+    comment: Spring + Winterwing
+    coord: [-3275, 2571]
+- _Tod::Noon:
+    comment: For Suma Sahma 4PM-5:30PM
+    notes: You can delay this according to your speed. Here's optimal because you
+      can use the cooking pot.
+- _Npc::Gerudo<Rhondson>:
+    comment: Options 1-1-1-2-1
+    coord: [-3269.43, 129.0, 2585.22]
+- _Npc::Rito<Ice Guy>:
+    comment: Options 2. Talk Again
+    notes: '[An Ice Guy] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3237.75, 2574.5]
+- SQ .dir(NE):
+    notes: Aim right in the middle of 2 trees
+- _Memory::KaraKaraBazaar:
+    time-override: 200
+- .dir(E>) Turn + .dir(E):
+    notes: Land on northmost statue with ball
+- The Seven Heroines:
+    notes: .link(https://tinyurl.com/Seven-Heroines)
+- _Shrine::KorshOhu
+- .dir(S) up + BLSS .dir(S>)
+- _Npc::Gerudo<Shrine Lady>:
+    notes: Finish [The Perfect Drink]
+    coord: [-2989, 3760.314947379851]
+- _Shrine::MisaeSuma
+- .dir(E) Turn + .dir(E) + .dir(E) + .dir(<<E) Turn:
+    movements:
+    - to: [-2442, 3746.5637825015438]
+    - to: [-2122, 3728.556869637083]
+- _Shrine::DilaMaag:
+    comment: Barb Armor
+    notes: '[The Desert Labyrinth] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- WB straight up land left:
+    coord: [-1808, 3343.409011147238]
+- .dir(E) + .dir(E) up:
+    coord: [-1603, 3343.409011147238]
+- .dir(S) + .dir(S) +.dir(N.) + midair:
+    movements:
+    - to: [-1614, 3587.5027188654785]
+    - to: [-1543, 3493.4666183510744]
+    - to: [-1395, 3503.470458831329]
+- Solve Puzzle
+- _Npc<Diary>:
+    comment: Text Options 2-1-3
+    notes: '[Secret of the Snowy Peaks] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- _Shrine::SumaSahma
+- _CheckQuests

--- a/routes/aq2/sections/hateno.yaml
+++ b/routes/aq2/sections/hateno.yaml
@@ -1,0 +1,70 @@
+- _Warp::Shrine::MyahmAgana
+- 'If rain: Go to BM branch and make night there. Come back and make noon.':
+    banner: true
+- SQ to Bolson:
+    notes: Aim left of house, where bolson is approximately at
+- _Npc<Bolson>:
+    coord: [3331.625, 2277.033772659286]
+- .dir(N>)
+- _Npc<Nebb>:
+    comment: Talk 9 Times
+    notes: '[The Weapon Connoisseur] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [3383.75, 2144.7461374377945]
+- _Npc<Farmer>:
+    notes: '[The Spring of Wisdom] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [3380.5, 2095.976824626766]
+- SQ to deck
+- _Npc<Lady at Deck>:
+    notes: '[Secret of the Cedars] Shrine Quest. Cannot do this quest when raining'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [3426.25, 2162.2530702417534]
+- _Npc<Cricket Guy>:
+    notes: '[A Gift for My Beloved] Side Quest'
+    coord: [3447.25, 2119.7362334321388]
+- _Npc<Inn Lady>:
+    icon-map: null
+    notes: Go inside the counter
+- _Npc<Cricket Guy>:
+    comment: Talk Twice
+    notes: Finish A Gift for My Beloved Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [3447.25, 2119.7362334321388]
+- .dir(E):
+    coord: [3626, 2103.4746457455212]
+- _Npc<Sheep Lady>:
+    notes: Finish Sheep Rustlers Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [3623, 2104.743471183565]
+- .dir(E) to Lab
+- Upgrade Sheika Sensor:
+    vars:
+      SideQuest: .add(1)
+    coord: [3780.5, 2127.9843516710644]
+- _Npc<Lab Assistant>:
+    comment: Talk 3 times
+    notes: '[Sunshroom Sensing] SideQuest'
+    vars:
+      SideQuest: .add(1)
+    coord: [3784, 2136.9879171130997]
+- .dir(NE) + .dir(NE)
+- _Shrine::TahnoOah
+- .dir(N) + .dir(N) + .dir(N) + .dir(E) + .dir(<E):
+    coord: [4168, 1248.6791102167554]
+- _Shrine::JitanSami:
+    notes: You don't need to free Naydra for the quest
+- BLSS .dir(N>)
+- _Shrine::ShaiYota
+- SQ .dir(SW):
+    coord: [4168, 357.49806499336955]
+- _Npc<Kass>:
+    notes: '[Master of the Wind] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- _CheckQuests

--- a/routes/aq2/sections/hebra.yaml
+++ b/routes/aq2/sections/hebra.yaml
@@ -1,0 +1,49 @@
+- _Warp::Beast::Medoh:
+    color: '#00ff00'
+- .dir(W) turn
+- _Npc::Rito<Little Bird>:
+    notes: '[Recital at Warbler''s Nest] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3971.25, -1745.5]
+- .dir(N>) Turn
+- _Shrine::ShaWarvo
+- .dir(<N) MAX HEIGHT
+- _Shrine::MakaRah
+- Run out:
+    coord: [-3984, -2549.3553557229257]
+- .dir(E) HIGH:
+    coord: [-3859, -2534.3494133195322]
+- .dir(N.) + .dir(E) midair:
+    movements:
+    - to: [-3807, -2720.4230991216104]
+    - to: [-3655, -2710.419137519348]
+- .dir(N) + .dir(N) midair:
+    coord: [-3575, -3031.5463049519667]
+- _Shrine::MozoShenno
+- .gale() + .dir(E>) + .dir(E) Turn:
+    gale: 1
+- _Boss::Talus::Frost:
+    comment: .fury()
+    fury: 3
+    coord: [-3078, -2933.6109706578454]
+- .dir(S) + .dir(N) + .dir(N) + .dir(<E)
+- _Shrine::ShadaNaw
+- .dir(E>) + .dir(E) Turn right
+- _Shrine::RokUwog
+- .dir(N) + .dir(<E) Turn:
+    coord: [-2386, -3399.7266494439036]
+- _Shrine::ShaGehma
+- BLSS .dir(E) to labyrinth:
+    notes: '[Trial on the Cliff] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- _Shrine::QazaTokki:
+    comment: Barb Legging
+- .dir(S) up + BLSS .dir(E) to dark forest:
+    notes: '[Shrouded Shrine] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- _Shrine::KetohWawai:
+    notes: Back up ancient core here if you only have 1
+- _CheckQuests

--- a/routes/aq2/sections/kak1-hateno.yaml
+++ b/routes/aq2/sections/kak1-hateno.yaml
@@ -164,6 +164,6 @@
     coord: [3328.75, 2278.14]
     var-change:
       SideQuest: 1
-- use: ../common/check-quest.yaml
+- _CheckQuests
 - "":
     notes: Don't break lizal shield. Use Royal Claymore for tree cutting and stasis stuff. Use bow order is Swallow -> FDB. Use Falcon/GEB only when necessary (You will get these bows in the next section)

--- a/routes/aq2/sections/kak2-ruta.yaml
+++ b/routes/aq2/sections/kak2-ruta.yaml
@@ -1,0 +1,99 @@
+- _Warp::Shrine::TalohNaeg:
+    color: yellow
+- _Npc<Pumpkin Man>:
+    notes: It should be 5pm-8pm in which case you would meet him at the kitchen near
+      the bridge with fireflies (the lower one). During day time he will be working
+      in the pumpkin field.
+    coord: [1896.5, 1003.9813736707592]
+- SQ to Impa:
+    icon: npc-sheika-female
+    notes: '[Captured Memories] Main Quest'
+    vars:
+      MainQuest: .add(1)
+    coord: [1774.5, 984.9782111875575]
+- .dir(<<E) up
+- Activate Fairy Fountain:
+    coord: [1976.5, 845.9673167813362]
+- _Snap::Quest<Fairy Fountain>
+- .dir(N) + .dir(E>) Turn + .dir(SE):
+    notes: We are going north first to avoid loading in the blupee near lakna rokee,
+      otherwise it will not spawn later.
+    movements:
+    - to: [1976.5, 691.0347563463147]
+    - to: [2252.5, 813.081610205435]
+- Kill Goat:
+    coord: [2463.16, 320.31, 1092.85]
+- _Material<Raw Meat>
+- .dir(SE) to shrine
+- _Shrine::DowNaeh:
+    notes: Get luminous stone here if you still don't have 10 somehow.
+- .dir(N>) + .dir(.E) Turn:
+    coord: [2769, 1199.045317667018]
+- _Memory::LanayruRoad
+- _Snap::Quest<Lynel>:
+    icon-map: null
+    movements:
+    - push
+    - to: [3234.5, 1181.649154325174]
+      color: white
+      icon: camera
+    - pop
+- .dir(E) + .dir(<N) DT:
+    coord: [3388, 1104.3533241835285]
+- _Shrine::RuccoMaag
+- Climb right pillar:
+    notes: If rain, windbomb west
+- .dir(E) + .dir(E) + .dir(.N) + .dir(<N) Turn:
+    coord: [3493.5, 410.0512704114144]
+- .loc(Monument):
+    comment: Left of dam
+    icon: npc-zora-male
+    coord: [3397, 10.99405759660658]
+- .dir(W)
+- .loc(Monument):
+    comment: Side of mountain
+    icon: npc-zora-male
+    coord: [3261.5, 33.00277312158323]
+- .dir(W)
+- .loc(Monument):
+    comment: Below
+    icon: npc-zora-male
+    coord: [3093, 74.51921377097187]
+- .dir(.N) DT
+- .loc(Monument):
+    comment: Other side below Bridge
+    icon: npc-zora-male
+    coord: [3061, -225.5996342968965]
+- .dir(E>)
+- .loc(Monument):
+    comment: Side of mountain
+    icon: npc-zora-male
+    coord: [3258.5, -146.06813955891084]
+- .dir(N) Super:
+    coord: [3325, -515.3022702526114]
+- Enter Fish Drama:
+    icon: npc-zora-female
+    notes: '[Reach Zora''s Domain] Main Quest and [Divine Beast Vah Ruta] Main Quest'
+    vars:
+      MainQuest: .add(1)
+- _Shrine::NeezYohma
+- Mipha Memory:
+    icon: ruta-memory
+    # split-type: UserDefined
+    coord: [3302.5, -471.74772207869955]
+- .dir(E) + .dir(E>>)
+- Enter Ruta:
+    icon: ruta-enter
+    # split-type: UserDefined
+    coord: [3596.5, -342.79736404428513]
+- .gale() inside Ruta:
+    gale: 1
+- .important(EQUIP CRYO, GEB, AA)
+- Waterblight:
+    icon: ruta-done
+    notes: Cryo, Stasis, GEB 6AA all head
+    # split-type: UserDefined
+    time-override: 122
+    vars:
+      MainQuest: .add(1)
+    coord: [3675, -188.23615728933328]

--- a/routes/aq2/sections/kak3.yaml
+++ b/routes/aq2/sections/kak3.yaml
@@ -1,0 +1,180 @@
+- It is recommended that you learn from a vod for kak quests:
+    banner: true
+- _Warp::Shrine::TalohNaeg:
+    color: '#00ff00'
+    notes: Need to be not raining for Koko. Make noon until it's not raining
+- Cucoo at shrine
+- Cucoo top of roof:
+    coord: [1849.375, 973.7633936748916]
+- _Npc::SheikaMale<Cucoo Man>:
+    notes: '[Flown the Coop] Side Quest'
+    coord: [1832.75, 964.0030702417534]
+- _Npc::SheikaFemale<Cottla>:
+    comment: Second Option
+    notes: '[Playtime with Cottla] Side Quest'
+    coord: [1874.875, 961.3836410805752]
+- Catch Cottla:
+    vars:
+      SideQuest: .add(1)
+    movements:
+    - to: [1877.75, 1031.035380424356]
+      warp: True
+- Cucoo under hut:
+    coord: [1882, 1043.4151330186723]
+- Cucoo top of hut:
+    coord: [1910.625, 1004.2751071396724]
+- Cucoo near kitchen:
+    movements:
+    - to: [1893.375, 974.138537692902]
+    - to: [1833.125, 960.7584010505598]
+- _Npc::SheikaMale<Pikango>:
+    comment: Talk Twice
+    notes: '[Find the Fairy Fountain] Main Quest'
+    vars:
+      MainQuest: .add(1)
+    coord: [1828.75, 992.5143608082008]
+- _Npc::SheikaMale<Koko>:
+    comment: Finish all four
+    icon-map: null
+    notes: '[Koko''s Kitchen] [Cooking with Koko] [Koko Cuisine] [Koko''s Specialty]
+      Side Quests'
+    vars:
+      SideQuest: .add(4)
+    coord: [1798.25, 1016.2737696135737]
+- ''
+- _Tod::Night:
+    color: orange
+    notes: For the night cucoo + firefly. Cannot be raining or there won't be fireflies
+- ''
+- _Npc::SheikaFemale<Arrow Quest Lady>:
+    comment: B, talk again
+    notes: '[Arrows of Burning Heart] Side Quest'
+    coord: [1826.5, 1041.4893036738922]
+- Cucoo in orchard:
+    movements:
+    - to: [1862, 1005.6506352057067]
+    - to: [1833.125, 960.7584010505598]
+- Light torches
+- Cucoo by Pikango:
+    movements:
+    - to: [1826.875, 999.5232829115503]
+    - to: [1833.125, 960.7584010505598]
+- _Npc::SheikaMale<Cucco Man>:
+    notes: Finish Flown the Coop Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [1832.75, 964.0030702417534]
+- _Material<5 Fireflies>:
+    notes: Grab 5 fireflies as you run toward the house
+    coord: [1900.125, 977.1396898369785]
+- _Npc::SheikaFemale<Firefly Lady>:
+    comment: Twice, drop fireflies
+    notes: '[By Firefly''s Light] Side Quest. Make sure don''t scare her. talk twice,
+      drop fireflies. If you scared her, make sure to let her sit down before talking
+      again.'
+    vars:
+      SideQuest: .add(1)
+    coord: [1901, 1028.7342526310076]
+- ''
+- SQ to impa
+- _Npc::SheikaFemale<Impa>:
+    notes: Finish Free the Divine Beasts Quest
+    vars:
+      MainQuest: .add(1)
+    coord: [1776.75, 984.7168215810534]
+- _Npc::SheikaFemale<Paya>:
+    notes: '[The Stolen Heirloom] Shrine Quest'
+    # split-type: UserDefined
+    vars:
+      ShrineQuest: .add(1)
+    coord: [1775.75, 991.2193966225241]
+- ''
+- _Tod::Night:
+    comment: After fade out
+    icon-map: null
+- Walk + Climb to shrine:
+    notes: Make sure to finish shrine by 10:00PM.
+- _Shrine::TalohNaeg:
+    color: magenta
+- Glide to shop
+- _Npc::SheikaFemale<Arrow Quest Lady>:
+    notes: Finish Arrows of Burning Heart Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [1826.5, 1041.4893036738922]
+- _Equipment::Weapon<Traveller Sword>:
+    notes: Mag from waterfall by entrance.
+    coord: [1927.75, 985.9673167813362]
+- .important(Drop Ice Rod):
+    notes: Also drop Royal Claymore if you still have it
+- .gale() Up:
+    gale: 1
+- .important(DO NOT RUN)
+- .important(CROUCH APPROACH BRIDGE):
+    movements:
+    - to: [1979.5, 954.5501182673379]
+    - to: [2026, 960.5524225554909]
+- _Snap::Quest<Blupee>:
+    icon-map: null
+    movements:
+    - push
+    - to: [2039.5, 918.0361005144041]
+      color: white
+      icon: camera
+    - pop
+- Unstuck Dorian at 12:15AM
+- Kill .enemy(Blademaster):
+    notes: Make sure you have empty slot. GEB Fire Arrow Head x2. The windcleaver
+      might despawn after the cutscene so make sure to pick it up
+- _Equipment::Weapon<Windcleaver>:
+    coord: [2014, 957.4560262148889]
+- _Shrine::LaknaRokee
+- .dir(S.) + .dir(SE) super
+- _Shrine::KamUrog:
+    notes: Shoot cursed statue
+- _Tod::Noon:
+    icon-map: null
+- _Npc<Doctor>:
+    comment: Mash B
+    notes: '[The Cursed Statue] Shrine Quest. If it''s raining after making noon,
+      reload the autosave you got after making noon.'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [2504, 1518.5361496206433]
+- .dir(S) + BLSS .dir(SW) + .gale():
+    gale: 1
+- If you still need a blupee pic, get one here, then wb to cave:
+    banner: true
+- _Chest<Misko's Treasure>:
+    notes: Get sapphire in middle chest
+    coord: [1951, 2609.562943681468]
+- SQ .dir(NW) to shrine
+- _Shrine::TotoSah
+- .dir(N.) Turn super
+- _Memory::AshSwamp:
+    vars:
+      MainQuest: .add(1)
+- .dir(<<W) to horse, ride near stable:
+    coord: [1765, 2045.8746152883996]
+- _Tod::Morning:
+    notes: If you are barely sub 9, might be BM here
+- _Npc<Horse Guy>:
+    comment: B, talk again.
+    notes: '[Wild Horses] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [1747, 1924.3264818209127]
+- Ride horse to him
+- _Npc<Two Guys Inside>:
+    comment: Talk Twice
+    notes: '[Misko, the Great Bandit] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [1776.5, 1931.329254942496]
+- SQ to shrine
+- _Shrine::HaDahamar
+- .dir(<<W) + .dir(NW)
+- _Shrine::ReeDahee
+- Shield surf SCW
+- _Shrine::SheeVaneer
+- _Shrine::SheeVenath

--- a/routes/aq2/sections/korok-forest.yaml
+++ b/routes/aq2/sections/korok-forest.yaml
@@ -1,0 +1,56 @@
+- .dir(W) Fast Turn
+- BLSS .dir(W) to Oaki
+- _Npc<Start Oaki>:
+    comment: Walk a little towards him
+    notes: '[The Lost Pilgrimage] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [267, -2278.8126162129947]
+- ? Oaki takes 5m20s of gameplay time to walk to shrine. Take note of your speed timer,
+    subtract 5m20s so you know when Oaki is at the shrine
+  : banner: true
+- .dir(E) to top of Deku Tree
+- _Npc<Watson>:
+    notes: '[Riddles of Hyrule] Side Quest. Talk first to wake up, then drop Apple,
+      Sunshroom, Voltfin, Pumpkin, Hoof and talk again.'
+    vars:
+      SideQuest: .add(1)
+    coord: [426.75, -2175.9136370706824]
+- _Snap::Quest<Sunshroom>:
+    icon-map: null
+- Throw away Drillshaft
+- ''
+- Drop down into Deku Tree
+- _Cook<Fruitcake>:
+    comment: Wheat, Sugar, Berry, Melon
+    icon-map: null
+- Trade to 13 hearts:
+    comment: 5 more
+- ''
+- Korok Leaf if needed:
+    notes: Can get 3 static frogs before pulling MS. Can also activate shrine and
+      warp to it afterwards
+- Equip Guardian Axe:
+    notes: When you pull MS, the equipped weapon will get 40 durability. Fire rod
+      also works if you are slow and need to set extra TODs
+- Pull Master Sword:
+    notes: '[The Hero''s Sword] Main Quest'
+    vars:
+      MainQuest: .add(1)
+- _Equipment::Weapon<Master Sword>:
+    coord: [432.5, -2136.802514127226]
+- _Npc<Ice Rod Korok>:
+    icon-map: null
+    notes: '[A Freezing Rod] Side Quest'
+    vars:
+      SideQuest: .add(1)
+- ''
+- Start following Oaki
+- _Material<Farm 10 cricket + 5 frogs>
+- _Material<Nightshade>
+- _Material<Honey>:
+    comment: on the way to shrine
+    icon-map: null
+- _Shrine::DaagChokah:
+    notes: Can approach Oaki after "Woo! I finally made it!"
+    time-override: 300

--- a/routes/aq2/sections/korok-forest2.yaml
+++ b/routes/aq2/sections/korok-forest2.yaml
@@ -1,0 +1,24 @@
+- .dir(E>>) Fast Turn
+- _Shrine::KeoRuug
+- .dir(E)
+- _Npc<Minigame Korok>:
+    notes: '[Test of Wood] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [564.99, 264.83, -2160.65]
+- .dir(<<E)
+- _Shrine::MaagHalan
+- .important(SAVE + CLOSE GAME):
+    notes: You will respawn at the trial start if you do it here
+- .dir(SW) Super:
+    notes: Ideally super directly to the quest korok. If you missed the super or have
+      to land in the forest, do a <E wb
+- _Npc<Trial Korok>:
+    notes: '[Trial of Second Sight] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [360.5, -2055.2876581187425]
+- .dir(<W) Turn to lake:
+    coord: [28, -1846.705058711574]
+- _Shrine::KuhnSidajj
+- _CheckQuests

--- a/routes/aq2/sections/lake.yaml
+++ b/routes/aq2/sections/lake.yaml
@@ -1,0 +1,55 @@
+- .dir(E>) Turn
+- _Shrine::IshtoSoh
+- BLSS .dir(<N) to giant horse
+- Ride to Mounted Archery Camp:
+    notes: Kill any electric keese coming your way
+    time-override: 200
+    movements:
+    - to: [-1208, 2652]
+    - to: [-636, 3722]
+    - to: [-200, 3500]
+- _Npc<Standing Guy at Camp>:
+    notes: '[Hunt for the Giant Horse] Side Quest'
+    vars:
+      SideQuest: .add(1)
+- .dir(SE) + .dir(SE)
+- _Npc<Guardian Girl>:
+    comment: Talk Twice
+    icon-map: null
+    notes: '[Guardian Slideshow] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [109, 3823.131728472772]
+- _Tod::Morning:
+    notes: For Highland Stable and Goron City Quests
+- _Shrine::ShoqaTatone
+- .dir(E) + .dir(E) + .dir(N>):
+    coord: [334.5, 3853.7939887635766]
+- _Shrine::KaoMakagh
+- .dir(N) Turn .fury() .enemy(Bokos):
+    fury: 1
+    notes: Fury then AA the rest. Use fire rod to fury so you can get an updraft as
+      well.
+    coord: [488, 3313.4692913392537]
+- .dir(<S)
+- _Material<Swift Carrot>:
+    comment: Behind horses
+    icon-map: null
+- _Npc<Old Lady>:
+    comment: Talk Once
+    notes: '[The Horseback Hoodlums] Side Quest. He is at the horses, or inside if
+      raining'
+    vars:
+      SideQuest: .add(1)
+    coord: [511, 3442]
+- .dir(N.) Turn
+- _Shrine::PumaagNitae
+- .dir(E.)
+- _Npc<Kass>:
+    notes: '[The Serpent''s Jaws] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [830, 3054]
+- .dir(N) Super
+- _Shrine::ShaeKatha
+- _CheckQuests

--- a/routes/aq2/sections/naboris.yaml
+++ b/routes/aq2/sections/naboris.yaml
@@ -1,0 +1,240 @@
+- _Warp::Shrine::MoggLatan:
+    color: '#00ff00'
+- BLSS .dir(W) + WB .dir(W) x2:
+    notes: Lightning pedestal on cliff. Shoot with FDB
+- _Shrine::KeehaYoog
+- BLSS .dir(E) to Camp:
+    movements:
+    - to: [-3568, 674.5062927691179]
+    - to: [-3272, 912.6005789029596]
+- _Chest<5 Fire Arrows>:
+    coord: [-3121.93, 550.32, 1325.76]
+- Melt Ice
+- ? Shoot 3 fire arrows while running to the ice. Use 4th fire arrow to light 3 wood.
+    Then light a normal arrow on fire to kill a wizrobe. If you need to set TOD, do
+    it now and use the last fire arrow to relight the fire Start farming luminous
+    stones around the shrine. After that put 3 more wood and you should have access
+    to the shrine. Need to be 12:40 to 13:30 when exiting shrine
+  : banner: true
+- _Tod::Noon:
+    comment: If needed see notes
+    coord: [-3071.21, 1236.58]
+- _Material<10 Luminous Stone>:
+    icon-map: null
+- _Equipment::Weapon<Ice Rod>:
+    coord: [-3076.7, 1226.9]
+- ? If it's after 13:30 when you activate Kuh Takkar, do Kuh Takkar later when you
+    warp back to ensure you make the Sasa Kai cycle
+  : banner: true
+- _Shrine::KuhTakkar
+- .dir(<W) BLSS off elevator
+- _Material<8 Berries>:
+    coord: [-3655.5, 1531.2579003072733]
+- .dir(<W) Turn
+- _Shrine::ShoDantu:
+    notes: Farm luminous to 10
+- .dir(S) + .dir(E):
+    coord: [-3874, 1827.213834933158]
+- _Npc<Kass>:
+    comment: Text Options 2-1
+    notes: '[Sign of the Shadow] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3672, 1845.2209658172305]
+- SQ to shrine:
+    notes: Shoot at sun 2:55-3:50
+- _Shrine::SasaKai
+- BLSS .dir(S) to Gerudo
+- _Shrine::DaqoChisay
+- _Npc<Benja>:
+    comment: After shrine
+    notes: '[Forbidden City Entry] Main Quest. Talking to him after shrine because
+      he takes forever to load.'
+    coord: [-3799.25, 2827.7960857630687]
+- BLSS .dir(NE)
+- _Shrine::DakoTah
+- .dir(E>) + .dir(E)
+- _Shrine::KayNoh
+- _Material<Flint>:
+    icon-map: null
+    notes: If you already have an rng one from the luminous ores, can skip this one
+- _Npc<Sesami>:
+    notes: '[Missing in Action] Side Quest'
+    coord: [-2814, 2239.51842145052]
+- _Shop<1 Winterwing 1 Darner>:
+    comment: Buy from Beedle
+    coord: [-2788.75, 2249.832302286999]
+- _Npc<Rushroom Guy>:
+    comment: Talk Twice
+    notes: '[Rushroom Rush!] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-2791.25, 2231.57507236287]
+- ''
+- .dir(<W) + .dir(SW)
+- Kara Kara:
+    icon: location
+    # split-type: UserDefined
+    coord: [-3264, 2608.325643705958]
+- Buy Gerudo clothes
+- .dir(SW) Super to Gerudo Town:
+    vars:
+      MainQuest: .add(1)
+- _Npc::Gerudo<Riju>:
+    notes: '[Divine Beast Vah Naboris] Main Quest'
+    coord: [-3882.5, 2964.225811328949]
+- _Warp::Shrine::KehNamut:
+    color: red
+- BLSS .dir(W):
+    notes: Toward single tree with a fire wizrobe. Kill it with ice rod
+- _Equipment::Weapon<Fire Rod>:
+    coord: [-2158, 2143.1041901394974]
+- Cut Tree .dir(SW)
+- _Material<Electric Darner>:
+    notes: Under pebble in water. Want to spam X + ZR to pull glider instantly and
+      AA the lizalfos
+    coord: [-2220.85, 356.03, 2204.36]
+- Cryo + .dir(N>) DT
+- _Npc<Friend 1>:
+    notes: AA 2 bokos
+    coord: [-2166, 1723.5268398553271]
+- Drop down
+- _Npc<Friend 2>:
+    notes: AA boko. If the boko with bow notices you, AA him as well.
+    coord: [-2187.5, 1692.2644598482575]
+- .dir(E>) Turn
+- _Npc<Friend 3>:
+    notes: RGC slam ground. Don't slam boko since that takes extra durability
+    coord: [-2053.75, 1741.2838716993429]
+- .dir(S)
+- _Npc<Friend 4>:
+    notes: RGC slam ground.
+    coord: [-2059.875, 1836.6678348244604]
+- .dir(<<<S) Slight Turn:
+    notes: Break the boxes and aim a bit left of a ladder in front of you
+- _Shrine::JeeNoh
+- .dir(N>) Turn + .dir(N) Turn
+- _Shrine::DahKaso:
+    comment: Get core
+- .dir(S) + .dir(<S) Turn
+- Talk a horse. Ride to horse guy:
+    notes: Land near a boko on horse, run up to him, AA the boko and instantly get
+      on the horse
+- _Npc<Horse Quest>:
+    notes: '[Good-Sized Horse] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    movements:
+    - to: [-1628, 2090.083193647508]
+    - to: [-1650, 2265.6527197672103]
+    - to: [-1696.5, 2302.6673776955804]
+    - to: [-1832.5, 2307.6693584967115]
+    - to: [-1992, 2164.112509504248]
+    - to: [-2031, 1880.5001980801135]
+- .dir(N.)
+- Do Test of Will:
+    notes: Combine stacks and bake an apple on phase 2
+- _Shrine::JolooNah:
+    notes: '[Test of Will] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- .dir(<W) + .dir(<<W) Turn:
+    notes: can also BLSS but it's a bit monkaSTEER
+- _Npc<Sesami>:
+    vars:
+      SideQuest: .add(1)
+    coord: [-2814, 2239.51842145052]
+- _Warp::Shrine::KuhTakkar
+- .dir(W) kill some wolves:
+    notes: Slam with Royal Claymore to kill 2 farthest
+    coord: [-3204, 1168.4056680716558]
+- _Material<Raw Gourmet Meat>
+- .dir(W) Turn:
+    coord: [-3516, 1356.1299405542022]
+- Clip in to Yiga Hideout
+- _Equipment::Bow<Duplex Bow>
+- Equip GEB and AA
+- Kill .enemy(Kohga):
+    notes: 'Phase 1: spam AA after screen goes out. Phase 2: wait for the ball to
+      go above, shoot 2 AA, run over the hole, spam AA. Phase 3: Mag the ball to kohga
+      from the side and press B as the ball goes over the edge of the hole. Or just
+      do normal kill'
+- _Warp::Shrine::DaqoChisay
+- _Shop<1 Durian>:
+    comment: For quest
+    coord: [-3822.5, 2878.1249885513744]
+- _Npc::Gerudo<Flint Lady>:
+    comment: Talk Twice
+    notes: '[Tools of the Trade] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3825, 2897.171471657931]
+- _Shop<All Fire + Shock>:
+    notes: Fire for shrines, shock for Ruta + fighting stuff. Technically only need
+      less than 10 fire arrows, but just in case
+    coord: [-3853.875, 2912.5337231392577]
+- Run to Riju
+- Urbosa Memory:
+    comment: Text Options 1-2
+    icon: naboris-memory
+    # split-type: UserDefined
+    coord: [-3869, 2947.3173472384588]
+- .dir(E>>) Super:
+    coord: [-3435, 3128.181045223386]
+- Ride sand seal .dir(SW):
+    notes: '[The Perfect Drink] Shrine Quest. There should be a small mountain'
+    vars:
+      ShrineQuest: .add(1)
+- _Npc::Gerudo<Shrine Lady>:
+    coord: [-2989, 3760.314947379851]
+- .dir(E) Turn to Naboris
+- Enter Naboris:
+    icon: naboris-enter
+    # split-type: UserDefined
+    coord: [-2476, 3764.5593782394317]
+- .gale() inside Naboris:
+    gale: 2
+- .important(EQUIP STASIS, GEB, AA)
+- Thunderblight:
+    icon: naboris-done
+    notes: Stasis, GEB 2 body 3 head. (bomb self after exiting beast in case ragdoll
+      glitch fails)
+    # split-type: UserDefined
+- _Npc<Boots Guy>:
+    comment: Equip snowboots
+    notes: '[The Eighth Heroine] Side Quest'
+    movements:
+    - to: [-3767.25, 2865.0417949038665]
+      warp: True
+- Run to Riju
+- _Npc::Gerudo<Riju + Thunderhelm>:
+    notes: '[The Thunder Helm] Side Quest'
+    vars:
+      MainQuest: .add(1)
+    coord: [-3888.5, 2970.333490767677]
+- _Npc::Gerudo<Guard Captain>:
+    notes: '[The Search for Barta] Side Quest'
+    coord: [-3911.75, 2929.317248198402]
+- _Npc::Gerudo<Side Entrance Guard>:
+    notes: '[The Silent Swordswomen] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3916.75, 2873.2950632257334]
+- _Npc::Gerudo<Historian>:
+    comment: Text Options 1-1-2
+    notes: '[The Seven Heroines] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3880.25, 2879.5475392271474]
+- _Npc::Gerudo<Bar Lady>:
+    notes: Progress The Perfect Drink Quest
+    coord: [-3852.75, 2860.289913142792]
+- _Npc::Gerudo<Berry Girl>:
+    notes: '[The Mystery Polluter] Side Quest'
+    coord: [-3834.75, 2853.287140021209]
+- .dir(N>) Turn
+- _Npc::Gerudo<Ice Minigame>:
+    movements:
+    - to: [-3755, 2279.955233894437]
+    - to: [-3762.75, 2699.025255214422]
+- _CheckQuests

--- a/routes/aq2/sections/plateau.yaml
+++ b/routes/aq2/sections/plateau.yaml
@@ -19,6 +19,8 @@
     comment: These are food
 - Surf down to TOT:
     notes: "[Follow the Sheikah Slate] Main Quest"
+    vars:
+      MainQuest: .add(1)
 - Clip through
 - _Equipment::Bow<Bow + Arrow>:
     coord: [-832.0, 1963.56]
@@ -27,11 +29,11 @@
 - BLSS
 - _Shrine::JaBaij
 - BLSS
-- _Tower::GreatPlateau:
-    vars:
-      MainQuest: .add(1)
+- _Tower::GreatPlateau
 - Jump down + FDC:
     notes: "[The Isolated Plateau] Main Quest"
+    vars:
+      MainQuest: .add(1)
 - BLSS to mag
 - _Shrine::OmanAu
 - _Chest<Amber>:
@@ -49,6 +51,6 @@
 - _Plateau:
     notes: "[Destroy Ganon] Main Quest and [Seek Out Impa] Main Quest"
     vars:
-      MainQuest: .add(1)
+      MainQuest: .add(2)
 - ".link([Example inventory after Plat]: https://ist.itntpiston.app/?r=init+1+tree+branch+1+axe+1+spear%5Bequip%5D+1+traveler+bow%5Bequip%5D+5+arrow%5Bequip%5D+1+potlid%5Bequip%2C+life%3D300%5D+1+flint+6+pepper+3+shroom+1+amber+1+slate+4+orb+1+glider)"
-- use: ../common/check-quest.yaml
+- _CheckQuests

--- a/routes/aq2/sections/rito.yaml
+++ b/routes/aq2/sections/rito.yaml
@@ -1,0 +1,73 @@
+- _Warp::Beast::Medoh:
+    notes: Coordinates in rito might not be accurate
+- _Npc::Rito<Singing Little Bird>:
+    comment: Drop down toward shrine
+    coord: [-3634.46, 292.22, -1784.51]
+- _Npc::Rito<Kheel's Mom>:
+    comment: Platform near shrine
+    notes: '[Find Kheel] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3668.51, 321.49, -1769.96]
+- _Shrine::AkhVaquot
+- .dir(.S) Turn + Shoot fire arrow
+- _Shrine::BareedaNaag
+- .dir(NE)
+- _Npc::Rito<Guard>:
+    comment: Talk Twice
+    notes: '[Face the Frost Talus] Side Quest. Near first bridge'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3355.5, -1805.8767941696433]
+- SQ to stable
+- _Npc<Old Man>:
+    comment: Talk Twice
+    notes: '[Curry for What Ails You] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3268.5, -1772.8637208821783]
+- .dir(W>)
+- _Npc::Rito<Fishing Little Bird>:
+    coord: [-3488.88, 258.52, -1850.25]
+- .dir(.W) to deck
+- _Npc::Rito<Rito Lady on Deck>:
+    notes: '[The Ancient Rito Song] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3605.16, 289.12, -1852.43]
+- Run up
+- _Npc<Apple Lady>:
+    comment: Talk Twice
+    notes: '[The Apple of My Eye] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-3615.92, 287.6, -1828.99]
+- Drop down 1 level
+- _Npc::Rito<Shrine Little Bird>:
+    notes: '[The Bird in the Mountains] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-3647.48, 289.88, -1822.09]
+- Drop down to shop
+- _Npc::Rito<Shopping Little Bird>:
+    coord: [-3637.58, 289.95, -1815.48]
+- Run up 3 houses
+- "_Cook<Salmon Meuni\xE8re>":
+    comment: Wheat, Butter, Salmon
+    icon-map: null
+- _Npc::Rito<Hungry Little Bird>:
+    coord: [-3596.62, 317.93, -1794.98]
+- Drop down
+- _Npc::Rito<Fyson>
+- Run up 1 house
+- _Npc<Flint Guy>:
+    comment: Talk Twice
+    notes: '[The Spark of Romance] Side Quest'
+    vars:
+      SideQuest: .add(1)
+- Drop out .dir(W) Turn
+- _Shrine::VooLota:
+    comment: 45312
+    notes: Start from 4 and blow every other hole while turning to the right. Make
+      sure pedestal is blue after first blow
+- _CheckQuests

--- a/routes/aq2/sections/rudania.yaml
+++ b/routes/aq2/sections/rudania.yaml
@@ -1,0 +1,79 @@
+- _Warp::Shrine::ShaeMosah:
+    color: yellow
+    comment: Goron City
+- SQ to Bludo
+- Daruk Memory:
+    icon: rudania-memory
+    # split-type: UserDefined
+    coord: [1708.5, -2451.0614048350653]
+- .dir(<S) + .dir(E) super:
+    coord: [1762, -2359.327977013841]
+- _Shrine::DaqaKoh
+- .dir(<W)
+- _Equipment::Weapon<Drillshaft>:
+    comment: Up behind bombable rocks
+    notes: Destroy the lizal shield if you still have it, or just throw a bomb
+    coord: [1946.8, 632.72, -2203.24]
+- .dir(.S) Turn
+- _Npc::Goron<Digging Goron>:
+    movements:
+    - to: [2003, -2036.393630979258]
+    - to: [1827.5, -1890.3357915862289]
+    - to: [2005.5, -2035.393234819032]
+- .dir(SW) to rock
+- Golden Gautlet rock up
+- Burn FDB:
+    notes: We will get a new one in Korok Forest if we don't have one
+- _Shrine::KayraMah
+- Run out + .dir(.N) + .dir(<E):
+    coord: [1982, -2143.7089192814583]
+- Kill .enemy(Moblins):
+    coord: [2141, -2282.6549949365435]
+- .fury() Enter Rudania:
+    fury: 2
+    icon: rudania-enter
+    notes: AA and use all fury. Pick up 3 screws. For the hard moving ones, stasis
+      them and shoot or shoot in BT. Make sure falcon bow is not broken, because we
+      need it for Sheem Dagoze
+    # split-type: UserDefined
+- ''
+- .gale() inside:
+    gale: 1
+- .important(EQUIP BARB, STASIS, GEB, AA):
+    notes: Equip before activating fight
+- Fireblight:
+    icon: rudania-done
+    notes: Stasis, GEB 1 body 4 head
+    # split-type: UserDefined
+- SQ .dir(NE) to talus quest:
+    notes: GC quests 8AM - 8PM. Make noon if not
+    movements:
+    - to: [1625.5, -2435.27733505561]
+      warp: True
+    - to: [1667.25, -2466.789814102736]
+- _Npc::Goron<Talus Quest Goron>:
+    comment: Talk Twice
+    notes: '[The Road to Respect] Side Quest'
+    vars:
+      SideQuest: .add(1)
+- Run
+- _Npc::Gerudo<Amber Lady>:
+    comment: Talk Twice
+    notes: '[The Jewel Trade] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [1678.75, -2445.781494737985]
+- _Npc::Goron<Bludo>:
+    notes: No need to grab reward
+    vars:
+      MainQuest: .add(1)
+    coord: [1708.5, -2451.0614048350653]
+- ''
+- .dir(S) + .dir(SE):
+    coord: [1684, -2365.9891055937787]
+- _Npc::Goron<Drillshaft Kid>:
+    notes: '[Death Mountain''s Secret] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [1794.5, -2251.943943327989]
+- _CheckQuests

--- a/routes/aq2/sections/tarrey-activate-gerudo.yaml
+++ b/routes/aq2/sections/tarrey-activate-gerudo.yaml
@@ -1,0 +1,74 @@
+- _Warp::Shrine::DahHesho:
+    color: red
+- .dir(N.) Turn to Tarrey Town:
+    coord: [3984.5, -1597.5796282054716]
+- _Npc<Hudson>:
+    comment: Talk twice
+- .dir(S) + .dir(S) + .dir(<S) Turn midairs
+- _Shrine::KenaiShakah:
+    comment: Behind bomb-able rocks
+- Jump out + .dir(SE) midair:
+    notes: Strong wind
+- Updraft + .dir(NE) super
+- _Shrine::KahMael
+- .gale() + .dir(.N) Turn:
+    gale: 1
+- .important(READ TABLET):
+    notes: '[Into the Vortex] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- .important(READ TABLET)
+- .important(READ TABLET)
+- BLSS with orb:
+    coord: [4627.5, -1825.25]
+- _Shrine::RitaagZumo
+- .dir(N) + .dir(<N) midairs
+- _Shrine::KatosaAug
+- _Npc<Guard>:
+    comment: Talk Twice
+    notes: '[A Shady Customer] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [4243.71, -2746.65]
+- _Npc<Cooking Pot Lady>:
+    comment: 2nd text option
+    notes: '[The Spring of Power] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [4245.96, -2747.83]
+- .dir(N) midairs
+- Smuggle blue flame:
+    notes: Use boko spear
+    time-override: 60
+    coord: [4153.5, -3173]
+- .dir(E) super to lab:
+    notes: Throw away boko spear
+    coord: [4506, -3168]
+- _Npc<Robbie>:
+    comment: Second options
+    notes: '[Robbie''s Research] Side Quest'
+    vars:
+      SideQuest: .add(1)
+- _Npc<Robbie's Wife>:
+    notes: '[The Skull''s Eye] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+- _Equipment::Weapon<Ancient Short Sword>:
+    comment: Buy from Cherry
+- .dir(N>) Turn:
+    notes: '[Trial of the Labyrinth] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [4627.5, -3683.5]
+- _Shrine::TuKaloh:
+    comment: Barb Helm
+- _Snap::Quest<Skywatcher>:
+    notes: Snap right after coming out of the shrine
+    icon-map: null
+    movements:
+    - push
+    - to: [4654.25, -3653.478781346587]
+      color: white
+      icon: camera
+    - pop
+- _CheckQuests

--- a/routes/aq2/sections/tarrey-activate-goron.yaml
+++ b/routes/aq2/sections/tarrey-activate-goron.yaml
@@ -1,0 +1,108 @@
+- .dir(N>) delay:
+    movements:
+    - to: [3284.5, -430.83222614419265]
+      warp: True
+- Talk to King
+- _Chest<Lightscale Trident>:
+    coord: [3331.5, -539.2848849971588]
+- ? TOD here should be before 7AM. If you mess up too much it will be after 7AM, in
+    which case it will be better to do diving quest first, then fronk (at pillar),
+    then WB to shrine from fronk, and do lynel lady on second visit
+  : banner: true
+- _Npc::ZoraFemale<Lynel Picture Lady>:
+    comment: Talk Twice
+    notes: '[Lynel Safari] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [3349.375, -509.8367705381688]
+- _Npc::ZoraMale<Fronk>:
+    comment: 8PM-7AM at SPA
+    notes: '[A Wife Washed Away] Side Quest'
+    time-override: 30
+    coord: [3340.375, -535.4719221439664]
+- _Npc::ZoraMale<Diving Quest>:
+    comment: midair after swimming up
+    notes: '[Diving is a Beauty] Side Quest'
+    coord: [3292.625, -519.5906331003753]
+- ''
+- .dir(W) Activate Shrine:
+    coord: [3082.75, -455.625]
+- _Shrine::DagahKeek
+- .dir(<<W) Ordinal Turn
+- Throw trident at Hinox:
+    notes: This should load him more consistently but unsure
+- _Boss::Hinox::Blue:
+    comment: .fury()
+    fury: 3
+    coord: [2923, -290.92037179452836]
+- .dir(S.) Turn (can super)
+- .loc(Monument):
+    comment: Below Ruta
+    icon: npc-zora-male
+    coord: [2838.5, 188.50332156742115]
+- .dir(<W) to deer:
+    coord: [2492, 339.23175373234244]
+- Ride to pedestal:
+    time-override: 20
+- _Npc<Kass>:
+    notes: '[The Crowned Beast] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [2576, 481.28800848446645]
+- _Shrine::MezzaLo
+- .dir(N.) DT
+- _Npc::ZoraFemale<Letter Girl>:
+    notes: '[Special Delivery] Side Quest'
+    coord: [2749, -88.23029102874534]
+- Bomb Letter
+- .dir(E)
+- .loc(Monument):
+    comment: Near many lizalfos
+    icon: npc-zora-male
+    coord: [2867, -71.59968009139811]
+- .loc(Monument):
+    comment: Run to the other side
+    icon: npc-zora-male
+    coord: [2879, -33.08442792268852]
+- .dir(W>)
+- _Npc<Letter Quest>:
+    notes: Pick up the letter and walk along the passage. Can pick up 2 frogs here
+      too. Then continue walking to a tree to blss
+    time-override: 30
+    movements:
+    - to: [2732.5, -82.47801310744399]
+    - to: [2661, -147.41660827237956]
+    - to: [2603, -161.9223525956595]
+    - to: [2237, -198.7975621243986]
+    - to: [1780, -78.75002289725126]
+- .dir(<E) Turn + .dir(.E) Turn
+- _Shrine::SohKofi:
+    notes: Can get a Knight's Bow for Eldin if needed. Drop swallow bow if you don't
+      have a slot.
+- Elevator BLSS .dir(E)
+- _Shrine::ShehRata
+- .dir(<N) Turn (super)
+- _Shrine::MirroShaz:
+    time-override: 40
+- SQ .dir(<S)
+- Kill .enemy(Octorok):
+    notes: Get Octoballoon. Not guaranteed, 84%. We do the shrine so that it's less
+      time loss to rng
+    coord: [1257, -1111.1588602507172]
+- .dir(W)
+- _Npc<Balloon Girl>:
+    comment: Put balloon, break barrel
+    notes: '[Balloon Flight] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [1066, -1136.1687642563725]
+- .dir(W) + .dir(S.)
+- _Shrine::NamikaOzz:
+    comment: Snap and kill
+    notes: Eat ATK 3, stasis + 4AA headshots with GEB. Snap. Grab axe and Frostspear
+      in chest
+    time-override: 30
+- _Equipment::Weapon<Axe and Frostspear>:
+    comment: For Nebb
+    icon-map: null
+- _CheckQuests

--- a/routes/aq2/sections/tarrey-activate-hateno.yaml
+++ b/routes/aq2/sections/tarrey-activate-hateno.yaml
@@ -1,0 +1,6 @@
+- _Warp::Shrine::DahHesho
+- .dir(N) Turn to Tarrey Town:
+    notes: This time he is by Rhonson
+    coord: [3949, -1631.4679110216753]
+- _Npc<Hudson>:
+    notes: Text 1112

--- a/routes/aq2/sections/tarrey-activate-rito.yaml
+++ b/routes/aq2/sections/tarrey-activate-rito.yaml
@@ -1,0 +1,24 @@
+- _Warp::Shrine::DahHesho:
+    color: cyan
+- .dir(N.) to Tarrey Town:
+    coord: [3984.5, -1597.5796282054716]
+- _Npc<Hudson>:
+    comment: Talk twice
+- Listen at window
+- _Npc<Mom>:
+    notes: '[A Parent''s Love] Side Quest. Give cake'
+    coord: [3969.5, -1571.6085339409033]
+- _Npc<Mom Again>:
+    comment: After Fade Out
+    icon-map: null
+    vars:
+      SideQuest: .add(1)
+- _Npc<Dad>:
+    comment: Talk Twice
+    notes: '[Hobbies of the Rich] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [3917.75, -1605.746639579776]
+- BLSS .dir(<N)
+- _Memory::SpringofPower
+- _Shrine::TutsuwaNima

--- a/routes/aq2/sections/tarrey-activate-zora.yaml
+++ b/routes/aq2/sections/tarrey-activate-zora.yaml
@@ -1,0 +1,6 @@
+- _Warp::Shrine::DahHesho:
+    color: cyan
+- .dir(N.) Turn:
+    coord: [3984.5, -1597.5796282054716]
+- _Npc<Hudson>:
+    notes: Talk Twice

--- a/routes/aq2/sections/tarrey-final.yaml
+++ b/routes/aq2/sections/tarrey-final.yaml
@@ -1,0 +1,11 @@
+- _Warp::Shrine::DahHesho
+- .dir(N.) Turn:
+    coord: [3949, -1631.4679110216753]
+- _Npc<Hudson>
+- Check after wedding if the only active quest is From the Ground Up (press +):
+    banner: true
+- _Npc<Hudson>:
+    comment: Talk again after wedding
+    notes: Finish From the Ground Up
+    vars:
+      SideQuest: .add(1)

--- a/routes/aq2/sections/thundra-plateau.yaml
+++ b/routes/aq2/sections/thundra-plateau.yaml
@@ -1,0 +1,31 @@
+- _Warp::Shrine::TenaKosah:
+    color: orange
+- _Shrine::TenaKosah
+- .dir(.E) DT
+- _Npc<Shrine Guy>:
+    notes: '[Cliffside Etchings] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [-2944.5, -497.92136219509393]
+- _Npc<Fairy Fountain Guy>:
+    comment: Talk Twice
+    notes: '[A Gift for the Great Fairy] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [-2937.5, -563.4473106899122]
+- _Material<3 Berries>:
+    icon-map: null
+- .dir(S)
+- _Shrine::ShaeLoya
+- .dir(<<E) TS to red orb:
+    notes: '[Trial of Thunder] Shrine Quest. Equip Guardian Axe + Forest Dweller Shield.
+      6 Hits on red and orange orbs'
+    vars:
+      ShrineQuest: .add(1)
+- .dir(NW) to orange orb
+- .dir(S) to green orb
+- _Shrine::TohYahsa
+- .dir(N) + .dir(<N) Turn + .dir(W>) Turn:
+    coord: [-2344, -1316.2384884561884]
+- _Shrine::DunbaTaag
+- _CheckQuests

--- a/routes/aq2/sections/zd-quests.yaml
+++ b/routes/aq2/sections/zd-quests.yaml
@@ -1,0 +1,49 @@
+- _Warp::Shrine::NeezYohma
+- _Npc::ZoraFemale<Girl in front of statue>:
+    notes: '[The Ceremonial Song] Shrine Quest'
+    vars:
+      ShrineQuest: .add(1)
+    coord: [3300, -475.43938748538767]
+- _Npc::ZoraMale<Frog Boy>:
+    comment: Talk Twice
+    notes: '[Frog Catching] Side Quest. After 4pm he is near Fronk'
+    vars:
+      SideQuest: .add(1)
+    coord: [3302.25, -475.10152750659563]
+- _Npc::ZoraMale<Luminous Stone Guy>:
+    comment: Talk Twice
+    notes: '[Luminous Stone Gathering] Side Quest. The guy is working on a pillar
+      near entrance'
+    vars:
+      SideQuest: .add(1)
+    coord: [3289.5, -449.466375900799]
+- Run up stairs
+- _Npc::ZoraFemale<Letter Girl>:
+    notes: Finish Special Delivery Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [3266.75, -480.7287559078686]
+- Keep running up stairs
+- _Npc::ZoraMale<Diving Quest>:
+    notes: Finish Diving is a Beauty Quest
+    vars:
+      SideQuest: .add(1)
+    coord: [3292.625, -519.5906331003753]
+- Run toward the back
+- _Npc::ZoraFemale<Hinox Lady>:
+    comment: Talk Twice
+    notes: '[The Giant of Ralis Pond] Side Quest.'
+    vars:
+      SideQuest: .add(1)
+    coord: [3306.375, -538.6266836809618]
+- All the way at the back
+- _Npc::ZoraMale<Monument Guy>:
+    comment: Talk Twice
+    notes: '[Zora Stone Monuments] Side Quest'
+    vars:
+      SideQuest: .add(1)
+    coord: [3337, -559.6350030457124]
+- Front of spa area
+- _Npc::ZoraMale<Kapson>:
+    coord: [3332.5, -524.8712364778512]
+- _CheckQuests


### PR DESCRIPTION
I hope/think I did the migration correctly. The only thing I intentionally did not migrate was the old UserDefined splits.

When the route is compiled by celer the Side Quest counter at the very end only counts up to 74/77. I'm not sure if this indicates an error in migration or if the flaw was already present in the old route.